### PR TITLE
Mostrar y actualizar atributos de personaje en FCreateCharacter

### DIFF
--- a/src/main/java/org/aoclient/engine/gui/ImGUISystem.java
+++ b/src/main/java/org/aoclient/engine/gui/ImGUISystem.java
@@ -278,4 +278,10 @@ public class ImGUISystem {
         frms.clear();
     }
 
+    /**
+     * Devuelve una copia de la lista de formularios activos.
+     */
+    public java.util.List<Form> getActiveForms() {
+        return new java.util.ArrayList<>(frms);
+    }
 }

--- a/src/main/java/org/aoclient/engine/gui/forms/FCreateCharacter.java~
+++ b/src/main/java/org/aoclient/engine/gui/forms/FCreateCharacter.java~
@@ -268,15 +268,15 @@ public final class FCreateCharacter extends Form {
         );
 
         // Mostrar atributos
-        ImGui.setCursorPos(307, 232);
+        ImGui.setCursorPos(310, 232);
         ImGui.text(String.valueOf(fuerza));
-        ImGui.setCursorPos(307, 253);
+        ImGui.setCursorPos(310, 253);
         ImGui.text(String.valueOf(agilidad));
-        ImGui.setCursorPos(307, 275);
+        ImGui.setCursorPos(310, 275);
         ImGui.text(String.valueOf(inteligencia));
-        ImGui.setCursorPos(307, 298);
+        ImGui.setCursorPos(310, 298);
         ImGui.text(String.valueOf(carisma));
-        ImGui.setCursorPos(307, 320);
+        ImGui.setCursorPos(310, 320);
         ImGui.text(String.valueOf(constitucion));
 
         ImGui.end();

--- a/src/main/java/org/aoclient/network/protocol/handlers/DiceRollHandler.java
+++ b/src/main/java/org/aoclient/network/protocol/handlers/DiceRollHandler.java
@@ -20,24 +20,18 @@ public class DiceRollHandler implements PacketHandler {
         int carisma = data.readByte();
         int constitucion = data.readByte();
 
-        //UserAtributos(eAtributos.Fuerza) = data.ReadByte()
-        //    UserAtributos(eAtributos.Agilidad) = data.ReadByte()
-        //    UserAtributos(eAtributos.Inteligencia) = data.ReadByte()
-        //    UserAtributos(eAtributos.Carisma) = data.ReadByte()
-        //    UserAtributos(eAtributos.Constitucion) = data.ReadByte()
-        //
-        //    With frmCrearPersonaje
-        //        .lblAtributos(eAtributos.Fuerza) = UserAtributos(eAtributos.Fuerza)
-        //        .lblAtributos(eAtributos.Agilidad) = UserAtributos(eAtributos.Agilidad)
-        //        .lblAtributos(eAtributos.Inteligencia) = UserAtributos(eAtributos.Inteligencia)
-        //        .lblAtributos(eAtributos.Carisma) = UserAtributos(eAtributos.Carisma)
-        //        .lblAtributos(eAtributos.Constitucion) = UserAtributos(eAtributos.Constitucion)
-        //
-        //        .UpdateStats
-        //    End With
-
         playSound(SND_DICE);
 
-        Logger.debug("handleDiceRoll Cargado! - FALTA TERMINAR!");
+        try {
+            // Buscar el formulario FCreateCharacter abierto y actualizar atributos
+            for (var frm : org.aoclient.engine.gui.ImGUISystem.get().getActiveForms()) {
+                if (frm instanceof org.aoclient.engine.gui.forms.FCreateCharacter) {
+                    ((org.aoclient.engine.gui.forms.FCreateCharacter) frm).setAtributos(fuerza, agilidad, inteligencia, carisma, constitucion);
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            Logger.error("Error actualizando atributos en FCreateCharacter: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/org/aoclient/network/protocol/handlers/DiceRollHandler.java~
+++ b/src/main/java/org/aoclient/network/protocol/handlers/DiceRollHandler.java~
@@ -1,0 +1,51 @@
+package org.aoclient.network.protocol.handlers;
+
+import org.aoclient.network.ByteQueue;
+import org.aoclient.network.protocol.PacketHandler;
+import org.tinylog.Logger;
+
+import static org.aoclient.engine.Sound.SND_DICE;
+import static org.aoclient.engine.Sound.playSound;
+
+public class DiceRollHandler implements PacketHandler {
+    @Override
+    public void handle(ByteQueue data) {
+        if (data.checkPacketData(6)) return;
+
+        data.readByte();
+
+        int fuerza = data.readByte();
+        int agilidad = data.readByte();
+        int inteligencia = data.readByte();
+        int carisma = data.readByte();
+        int constitucion = data.readByte();
+
+        //UserAtributos(eAtributos.Fuerza) = data.ReadByte()
+        //    UserAtributos(eAtributos.Agilidad) = data.ReadByte()
+        //    UserAtributos(eAtributos.Inteligencia) = data.ReadByte()
+        //    UserAtributos(eAtributos.Carisma) = data.ReadByte()
+        //    UserAtributos(eAtributos.Constitucion) = data.ReadByte()
+        //
+        //    With frmCrearPersonaje
+        //        .lblAtributos(eAtributos.Fuerza) = UserAtributos(eAtributos.Fuerza)
+        //        .lblAtributos(eAtributos.Agilidad) = UserAtributos(eAtributos.Agilidad)
+        //        .lblAtributos(eAtributos.Inteligencia) = UserAtributos(eAtributos.Inteligencia)
+        //        .lblAtributos(eAtributos.Carisma) = UserAtributos(eAtributos.Carisma)
+        //        .lblAtributos(eAtributos.Constitucion) = UserAtributos(eAtributos.Constitucion)
+        //
+        //        .UpdateStats
+        //    End With
+
+        playSound(SND_DICE);
+
+        // Buscar el formulario FCreateCharacter abierto y actualizar atributos
+        for (var frm : org.aoclient.engine.gui.ImGUISystem.get().getActiveForms()) {
+            if (frm instanceof org.aoclient.engine.gui.forms.FCreateCharacter) {
+                ((org.aoclient.engine.gui.forms.FCreateCharacter) frm).setAtributos(fuerza, agilidad, inteligencia, carisma, constitucion);
+                break;
+            }
+        }
+
+        Logger.debug("handleDiceRoll Cargado! - FALTA TERMINAR!");
+    }
+}


### PR DESCRIPTION
- Se muestran y actualizan los atributos de personaje en FCreateCharacter tras la tirada de dados.
- Se añadió manejo de excepciones en DiceRollHandler.
- Se implementó el acceso limpio y seguro a los formularios activos mediante un método público en ImGUISystem, siguiendo buenas prácticas.